### PR TITLE
Fix typo

### DIFF
--- a/lib/pushwoosh/push_notification.rb
+++ b/lib/pushwoosh/push_notification.rb
@@ -55,7 +55,7 @@ module Pushwoosh
     def default_notification_options
       {
         send_date: "now",
-        ios_bagdes: "+1"
+        ios_badges: "+1"
       }
     end
   end


### PR DESCRIPTION
I noticed a typo causing badge icon counts not to be set.