### PR TITLE
Edits Pushwoosh::Response to inherit from OpenStruct

### DIFF
--- a/lib/pushwoosh/response.rb
+++ b/lib/pushwoosh/response.rb
@@ -1,12 +1,5 @@
+require 'ostruct'
+
 module Pushwoosh
-  class Response
-
-    attr_accessor :status_code, :status_message, :response
-
-    def initialize(pushwoosh_response = {})
-      @status_code = pushwoosh_response[:status_code]
-      @status_message = pushwoosh_response[:status_message]
-      @response = pushwoosh_response[:response]
-    end
-  end
+  class Response < OpenStruct; end
 end


### PR DESCRIPTION
This saves us lines of code, and we don't to manually specify the
attrs that a Pushwoosh::Response object responds to, as they're
the same attrs returned by the API call.