### PR TITLE
Remove Bundler as a Dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,10 +46,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.8.2)
   pry (= 0.10.1)
   pushwoosh!
   rake (~> 10.4.2)
   rspec (~> 3.1.0)
   vcr (~> 2.8.0)
   webmock (~> 1.15.0)
+
+BUNDLED WITH
+   1.10.6

--- a/pushwoosh.gemspec
+++ b/pushwoosh.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.8.2"
   spec.add_development_dependency "rake", '~> 10.4.2'
   spec.add_development_dependency 'rspec', "~> 3.1.0"
   spec.add_development_dependency 'vcr', "~> 2.8.0"


### PR DESCRIPTION
This removes bundler as a development dependency.

Having bundler as a dependency with a certain version, when the installed version is higher, causes a failure when trying to `bundle install` the deps for this gem locally for dev.

And besides, how could you possibly `bundle install` this gem, if you don't have bundler already installed. And that's the assumption that having bundler as a dep is making. So if you already have bundler installed, why have it as a dep.