### PR TITLE
Remove Truncation

### DIFF
--- a/lib/pushwoosh/helpers.rb
+++ b/lib/pushwoosh/helpers.rb
@@ -1,18 +1,6 @@
 module Pushwoosh
   module Helpers
     class << self
-      def limit_string(str, limit_bytes)
-        return '' if str.empty? || !str
-
-        str = str.mb_chars.compose.to_s if str.respond_to?(:mb_chars)
-        new_str = str.byteslice(0, limit_bytes)
-        until new_str[-1].force_encoding('utf-8').valid_encoding?
-          # remove the invalid char
-          new_str = new_str.slice(0..-2)
-        end
-
-        new_str
-      end
     end
   end
 end

--- a/lib/pushwoosh/push_notification.rb
+++ b/lib/pushwoosh/push_notification.rb
@@ -8,29 +8,23 @@ require 'pushwoosh/helpers'
 module Pushwoosh
   class PushNotification
 
-    STRING_BYTE_LIMIT = 205 # recommended value, see https://community.pushwoosh.com/questions/286/why-am-i-receiving-a-payload-error for more details
-
     def initialize(auth_hash = {})
       @auth_hash = auth_hash
     end
 
     def notify_all(message, other_options = {})
-      other_options.merge!(content: limited_content(message))
+      other_options.merge!(content: message)
       create_message(other_options)
     end
 
     def notify_devices(message, devices, other_options = {})
-      other_options.merge!(content: limited_content(message), devices: devices)
+      other_options.merge!(content: message, devices: devices)
       create_message(other_options)
     end
 
     private
 
     attr_reader :auth_hash
-
-    def limited_content(message)
-      Helpers.limit_string(message, STRING_BYTE_LIMIT)
-    end
 
     def create_message(notification_options = {})
       fail Pushwoosh::Exceptions::Error, 'Message is missing' if notification_options[:content].nil? || notification_options[:content].empty?

--- a/spec/pushwoosh/helpers_spec.rb
+++ b/spec/pushwoosh/helpers_spec.rb
@@ -1,12 +1,4 @@
 require 'spec_helper'
 
 describe Pushwoosh::Helpers do
-  describe '.limit_string' do
-    context 'when string is bigger than 256 bytes' do
-      it 'returns the string with 256 bytes' do
-        big_string = 'é' * 300
-        expect(described_class.limit_string(big_string, 256).bytes.size).to eq 256
-      end
-    end
-  end
 end


### PR DESCRIPTION
This removes the automatic truncation that happens on a notification.

Not only do all the platforms supported by Pushwoosh have differing limits, they're all very much larger than the 256 bytes assumed currently in the gem.

This removes truncation completely and leaves it up to the user of the gem to handle truncation themselves, which they can base on the specs of the platform that they are pushing to.

This resolves #8 

