### PR TITLE
Change JSON handling from to_json to multi_json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     pushwoosh (1.0.1)
       httparty (~> 0.13.3)
+      multi_json (~> 1.11)
 
 GEM
   remote: https://rubygems.org/
@@ -12,12 +13,13 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    httparty (0.13.3)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    json (1.8.2)
+    json (1.8.3)
     method_source (0.8.2)
-    multi_xml (0.5.5)
+    multi_json (1.12.1)
+    multi_xml (0.6.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -54,4 +56,4 @@ DEPENDENCIES
   webmock (~> 1.15.0)
 
 BUNDLED WITH
-   1.10.6
+   1.13.5

--- a/lib/pushwoosh/request.rb
+++ b/lib/pushwoosh/request.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'multi_json'
 
 module Pushwoosh
   class Request
@@ -26,7 +27,7 @@ module Pushwoosh
     end
 
     def make_post!
-      response = self.class.post(url, body: build_request.to_json).parsed_response
+      response = self.class.post(url, body: build_request_json).parsed_response
       Response.new(response)
     end
 
@@ -42,6 +43,10 @@ module Pushwoosh
 
     def build_request
       { request: full_request_with_notifications }
+    end
+
+    def build_request_json
+      MultiJson.dump(build_request)
     end
 
     def full_request_with_notifications

--- a/pushwoosh.gemspec
+++ b/pushwoosh.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', "~> 1.15.0"
   spec.add_development_dependency 'pry', '0.10.1'
   spec.add_dependency "httparty", "~> 0.13.3"
+  spec.add_dependency 'multi_json', '~> 1.11'
 end


### PR DESCRIPTION
This change the default json handling to multi_json because I wasn't able to send emoji. This new handler is default one in rails, rabl and jbuilder. Also you can set your own engine (from outside), like  [oj](https://github.com/ohler55/oj), so you can optimize the requests.